### PR TITLE
Extract file name from Perl code ref debugger output.

### DIFF
--- a/lib/VimDebug/DebuggerInterface/Perl.pm
+++ b/lib/VimDebug/DebuggerInterface/Perl.pm
@@ -135,17 +135,15 @@ sub parseForLineNumber {
 }
 
 sub _getFileAndLine {
-   # main::(/opt/apps/perl/bin/cpan:9): 
-   # Foo::meh(/some/where/Foo.pm:353):
-   # App::Cpan::run(/opt/apps/perl/lib/5.12.2/App/Cpan.pm:353):
-   # App::Cpan::CODE(0xa3fd670)(/opt/apps/perl/lib/5.12.2/App/Cpan.pm:459):
+   # See .../t/VD_DI_Perl.t for test cases.
    my ($str) = shift;
    $str =~ /
       ^ \w+ ::
-      (?:\w+::)*
-      (?:CODE\(0x\w+\)|\w+)?
+      (?: \w+ :: )*
+      (?: CODE \( 0x \w+ \) | \w+ )?
       \(
-         (.+) : (\d+)
+         (?: .* \x20 )?
+         ( .+ ) : ( \d+ )
       \):
    /xm;
    return ($1, $2);

--- a/t/VD_DI_Perl.t
+++ b/t/VD_DI_Perl.t
@@ -36,6 +36,11 @@ for my $t_ref (
       "App::Cpan::CODE(0xa3fd670)(/opt/apps/perl/lib/5.12.2/App/Cpan.pm:459):",
       qw<                         /opt/apps/perl/lib/5.12.2/App/Cpan.pm 459 >,
    ],
+   [
+      "Another code ref", 
+      "Class::Foo::CODE(0xa1e4988)(accessor amount defined at lib/Currency.pm:8):",
+      qw<                                                     lib/Currency.pm 8 >,
+   ],
 ) {
     my ($test_name, $str, $exp_f, $exp_l) = @$t_ref;
     my ($got_f, $got_l) = VimDebug::DebuggerInterface::Perl::_getFileAndLine($str);


### PR DESCRIPTION
This patch allows the file name to be properly extracted from strings like this one:

```
App::Cpan::CODE(0xa3fd670)(/opt/apps/perl/lib/5.12.2/App/Cpan.pm:459):
```
