### PR TITLE
Perl shebang fix

### DIFF
--- a/bin/vdd
+++ b/bin/vdd
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 # vdd
 # Vim Debugger Daemon
@@ -8,6 +8,7 @@
 # http://iijo.org
 
 use strict;
+use warnings;
 use File::Basename;
 use UNIVERSAL;
 use vars qw(

--- a/bin/vddTester
+++ b/bin/vddTester
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 # vddTester
 # Vim Debugger Daemon Tester
@@ -8,6 +8,7 @@
 # http://iijo.org
 
 use strict;
+use warnings;
 use Cwd;
 use File::Basename;
 use Term::ANSIColor;


### PR DESCRIPTION
This allowed me to try VimDebug with different perl versions locally, and I can well imagine that someone using perlbrew for example would be happy that the path to perl is not hard-coded in the programs (see the commit for more comments).
