### PR TITLE
Tiny vimscript fix

### DIFF
--- a/vim/plugin/VimDebug.vim
+++ b/vim/plugin/VimDebug.vim
@@ -434,7 +434,7 @@ function! s:HandleCmdResult(...)
 
    if match(l:cmdResult, '^' . s:LINE_INFO . '\d\+:.*$') != -1
       let l:cmdResult = substitute(l:cmdResult, '^' . s:LINE_INFO, "", "")
-      if a:0 <= 0 || (a:0 > 0 && match(a:1, 'breakpoint') == -1)
+      if a:0 == 0 || match(a:1, 'breakpoint') == -1
          call s:CurrentLineMagic(l:cmdResult)
       endif
       if a:0 > 0


### PR DESCRIPTION
Although it cannot cause an error, the problem with the original code is that it is misleading. I asked myself "Huh? What does a negative a:0 mean?" As the docs confirm, a:0 can only be 0 or greater. With the patch, future readers of the code shouldn't have to ask themselves the same question.
