### PR TITLE
Fix termination bug again

### DIFF
--- a/lib/VimDebug/DebuggerInterface/Perl.pm
+++ b/lib/VimDebug/DebuggerInterface/Perl.pm
@@ -123,7 +123,7 @@ sub parseForFilePath {
    my $self   = shift or die;
    my $output = shift or die;
    my ($filePath, undef) = _getFileAndLine($output);
-   $self->filePath($filePath);
+   $self->filePath($filePath || '');
    return undef;
 }
 
@@ -131,7 +131,7 @@ sub parseForLineNumber {
    my $self   = shift or die;
    my $output = shift or die;
    my (undef, $lineNumber) = _getFileAndLine($output);
-   $self->lineNumber($lineNumber);
+   $self->lineNumber($lineNumber || '');
    return undef;
 }
 


### PR DESCRIPTION
The tests expect the file name and line number to always be defined, so setting them to an empty string when none are found seems to fix it.
