### PR TITLE
Fix argument passing

### DIFF
--- a/vim/plugin/VimDebug.vim
+++ b/vim/plugin/VimDebug.vim
@@ -398,13 +398,10 @@ function! s:Incantation(...)
    let s:bufNr          = bufnr("%")
    let s:fileName       = bufname("%")
    let l:debugger       = s:DbgrName(s:fileName)
-   let l:vddIncantation = "vdd " . s:sessionId . " " . l:debugger . " "
+   let l:vddIncantation =
+    \ "vdd " . s:sessionId . " " . l:debugger . " " . s:AutoIncantation(l:debugger)
 
-   if a:1 == ''
-      return l:vddIncantation . s:AutoIncantation(l:debugger)
-   else
-      return l:vddIncantation . a:1
-   endif
+   return l:vddIncantation . (a:0 == 0 ? '' : (" " . join(a:000, " ")))
 endfunction 
 function! s:DbgrName(fileName)
    let l:fileExtension = fnamemodify(a:fileName, ':e')


### PR DESCRIPTION
This broke a while back actually, and we failed to notice it. There should probably be a test for it. Speaking of tests, running the tests on this will fail, until the fixTerminationBugAgain patch is applied.

Broken in c47e7111, "Launching vdd now requires a debugger command."
