### PR TITLE
Confess

### DIFF
--- a/bin/vdd
+++ b/bin/vdd
@@ -14,6 +14,7 @@ use warnings;
 use File::Basename;
 use UNIVERSAL;
 use POSIX ();
+use Carp;
 
 # constants
 my $LINE_INFO      = "vimDebug:";
@@ -131,7 +132,7 @@ sub logger {
 
 # blocks until there is something to read
 sub readFromVim {
-   open(my $ctlHandle, "<", $ctl_vimFIFOvdd) or act('quit');
+   open(my $ctlHandle, "<", $ctl_vimFIFOvdd) or confess;
    my $from = <$ctlHandle>;
    close($ctlHandle);
    logger("received '$from'") if $debug_option;
@@ -144,12 +145,12 @@ sub sendToVim {
    my $debugOutput = shift;
 
    logger("sending  '$stuffToSend'") if $debug_option;
-   open(my $ctlHandle, ">", $ctl_vddFIFOvim) or act('quit');
+   open(my $ctlHandle, ">", $ctl_vddFIFOvim) or confess;
    print {$ctlHandle} $stuffToSend;
    close($ctlHandle);
 
    logger("sending  '$debugOutput'") if $debug_option;
-   open(my $dbgHandle, ">", $dbg_vddFIFOvim) or act('quit');
+   open(my $dbgHandle, ">", $dbg_vddFIFOvim) or confess;
    print {$dbgHandle} $debugOutput;
    close($dbgHandle);
 }

--- a/lib/VimDebug/DebuggerInterface/Base.pm
+++ b/lib/VimDebug/DebuggerInterface/Base.pm
@@ -122,13 +122,14 @@ sub _startDebugger {
    return undef;
 }
 
+
 =head2 _command($command)
 
 Returns a string
 =cut
 sub _command {
-   my $self = shift or die;
-   my $command = shift or die;
+   my $self = shift or confess;
+   my $command = shift or confess;
 
    # write
    $WRITE .= "$command\n";
@@ -143,7 +144,6 @@ sub _command {
    $output =~ s/$prompt//os;
    return $output;
 }
-
 =head2 _quit($command)
 
 Returns undef (this is subject to change)
@@ -166,7 +166,7 @@ $VimDebug::DebuggerInterface::Base::debuggerPrompt is found.
 Returns undef (this is subject to change)
 =cut
 sub getUntilPrompt   {
-   my $self   = shift or die;
+   my $self   = shift or confess;
    my $prompt = $self->dbgrPromptRegex;
    my $output = '';
 
@@ -206,7 +206,7 @@ text.
 Returns $output cleansed
 =cut
 sub output {
-   my $self = shift or die;
+   my $self = shift or confess;
    my $output = '';
 
    if (@_) {
@@ -228,8 +228,8 @@ attributes.
 Returns undef;
 =cut
 sub parseOutput {
-   my $self   = shift or die;
-   my $output = shift or die;
+   my $self   = shift or confess;
+   my $output = shift or confess;
 
    $self->parseForLineNumber($output);
    $self->parseForFilePath($output);
@@ -244,7 +244,7 @@ Parses $output and sets $self->lineNumber($number) if possible.
 Returns undef;
 =cut
 sub parseForLineNumber {
-   my $self = shift or die;
+   my $self = shift or confess;
    confess "developers should implement this method in their modules";
    return undef;
 }
@@ -256,7 +256,7 @@ Parses $output and sets $self->filePath($path) if possible.
 Returns undef
 =cut
 sub parseForFilePath {
-   my $self = shift or die;
+   my $self = shift or confess;
    confess "developers should implement this method in their modules";
    return undef;
 }

--- a/lib/VimDebug/DebuggerInterface/Perl.pm
+++ b/lib/VimDebug/DebuggerInterface/Perl.pm
@@ -24,7 +24,7 @@ my  $finishedRegex      = qr/(\/perl5db.pl:)|(Use .* to quit or .* to restart)|(
 # callback functions implemented
 
 sub startDebugger {
-   my $self        = shift or die;
+   my $self        = shift or confess;
    my @incantation = @_;
 
    $ENV{"PERL5DB"}     = 'BEGIN {require "perl5db.pl";}';
@@ -36,27 +36,27 @@ sub startDebugger {
 }
 
 sub next {
-   my $self = shift or die;
+   my $self = shift or confess;
    $self->SUPER::_command("n");
    return undef;
 }
 
 sub step {
-   my $self = shift or die;
+   my $self = shift or confess;
    $self->SUPER::_command("s");
    return undef;
 }
 
 sub cont {
-   my $self = shift or die;
+   my $self = shift or confess;
    $self->SUPER::_command("c");
    return undef;
 }
 
 sub setBreakPoint {
-   my $self       = shift or die;
-   my $lineNumber = shift or die;
-   my $fileName   = shift or die;
+   my $self       = shift or confess;
+   my $lineNumber = shift or confess;
+   my $fileName   = shift or confess;
 
    $self->SUPER::_command("f $fileName");
    $self->SUPER::_command("b $lineNumber");
@@ -65,9 +65,9 @@ sub setBreakPoint {
 }
 
 sub clearBreakPoint {
-   my $self       = shift or die;
-   my $lineNumber = shift or die;
-   my $fileName   = shift or die;
+   my $self       = shift or confess;
+   my $lineNumber = shift or confess;
+   my $fileName   = shift or confess;
 
    $self->SUPER::_command("f $fileName");
    $self->SUPER::_command("B $lineNumber");
@@ -76,37 +76,37 @@ sub clearBreakPoint {
 }
 
 sub clearAllBreakPoints {
-   my $self = shift or die;
+   my $self = shift or confess;
    return $self->SUPER::_command("B *");
    return undef;
 }
 
 sub printExpression {
-   my $self       = shift or die;
-   my $expression = shift or die;
+   my $self       = shift or confess;
+   my $expression = shift or confess;
    return $self->SUPER::_command("x $expression");
 }
 
 sub command {
-   my $self = shift or die;
-   my $command = shift or die;
+   my $self = shift or confess;
+   my $command = shift or confess;
    return $self->SUPER::_command($command);
 }
  
 sub restart {
-   my $self = shift or die;
+   my $self = shift or confess;
    $self->SUPER::_command("R");
    return undef;
 }
 
 sub quit {
-   my $self = shift or die;
+   my $self = shift or confess;
    return $self->SUPER::_quit("q");
 }
 
 sub parseOutput {
-   my $self   = shift or die;
-   my $output = shift or die;
+   my $self   = shift or confess;
+   my $output = shift or confess;
 
    # take care of the problem case when we hit an eval() statement
    # example: main::function((eval 3)[debugTestCase.pl:5]:1):      my $foo = 1
@@ -120,16 +120,16 @@ sub parseOutput {
 }
 
 sub parseForFilePath {
-   my $self   = shift or die;
-   my $output = shift or die;
+   my $self   = shift or confess;
+   my $output = shift or confess;
    my ($filePath, undef) = _getFileAndLine($output);
    $self->filePath($filePath) if defined $filePath;
    return undef;
 }
 
 sub parseForLineNumber {
-   my $self   = shift or die;
-   my $output = shift or die;
+   my $self   = shift or confess;
+   my $output = shift or confess;
    my (undef, $lineNumber) = _getFileAndLine($output);
    $self->lineNumber($lineNumber) if defined $lineNumber;
    return undef;


### PR DESCRIPTION
These errors shouldn't happen if the program is behaving properly. It's more useful to have a stack trace instead of a die or of attempting to quit the debugger cleanly.
