### PR TITLE
Better quit behaviour

### DIFF
--- a/bin/vdd
+++ b/bin/vdd
@@ -107,9 +107,8 @@ sub makeNamedPipe {
    my $fifo = shift or die "gotta pass a fifo to this function";
 
    if (-p $fifo) {
-      print "vdd: $fifo already exists.  perhaps another instance of" .
-            " vimDebug is running?\nif not, just delete $fifo.\n";
-      exit();
+      die "vdd: $fifo already exists.  perhaps another instance of" .
+            " VimDebug is running?\nIf not, just delete $fifo.\n";
    }
 
    POSIX::mkfifo($fifo, 0700) or die "mkfifo $fifo failed: $!\n";


### PR DESCRIPTION
VimDebug still doesn't handle Ctrl-C (to break out of infinite loops for example) or getting user input (if the program reads &lt;STDIN&gt; for example), but this patch appears to deal better with many other exit situations.

It may be possible to refactor it to something a bit simpler eventually, but I believe this is already an important behaviour improvement.
