### PR TITLE
Have debugger values printed to the console.

### DIFF
--- a/lib/Vim/Debug/_vim/plugin/VimDebug.vim
+++ b/lib/Vim/Debug/_vim/plugin/VimDebug.vim
@@ -390,7 +390,7 @@ function! s:HandleCmdResult(...)
          call s:CurrentLineMagic(l:lineNumber, l:fileName)
       endif
       if len(l:value) > 0
-         echo l:value . "                    "
+         call s:ConsolePrint(l:value)
       endif
 
    elseif l:status == s:APP_EXITED


### PR DESCRIPTION
When we do a <Leader>v or <Leader>v/, when this VimDebug.vim's function
is called:

```
function! s:HandleCmdResult(...)
   let l:cmdResult  = split(s:SocketRead(), s:EOR_REGEX, 1)
   let [l:status, l:lineNumber, l:fileName, l:value, l:output] = l:cmdResult
```

'echo'ing a big l:value will either scroll off the screen or get us
dropped into Vim's "more" (depending on the setting of Vim's "more"
option). We instead print it to the console, making it easier to read or
copy and paste.
