### PR TITLE
Don't echo l:value after obtaining some debugger output.

### DIFF
--- a/lib/Vim/Debug/_vim/plugin/VimDebug.vim
+++ b/lib/Vim/Debug/_vim/plugin/VimDebug.vim
@@ -389,9 +389,6 @@ function! s:HandleCmdResult(...)
       if len(l:lineNumber) > 0
          call s:CurrentLineMagic(l:lineNumber, l:fileName)
       endif
-      if len(l:value) > 0
-         echo l:value . "                    "
-      endif
 
    elseif l:status == s:APP_EXITED
       call s:ConsolePrint(l:output)


### PR DESCRIPTION
l:value already appears in the l:output that is printed to console;
echoing it is not really useful, and it can be annoying to be dropped in
to Vim's "more" mode if the value is long.
