### PR TITLE
Add deprecation notice and metadata

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -4,7 +4,11 @@
 
 =head1 NAME
 
-Vim::Debug::Manual - Integrate the Perl debugger with Vim
+Vim::Debug::Manual - Integrate the Perl debugger with Vim (DEPRECATED)
+
+=head1 Deprecation Notice
+
+Please note that this module is deprecated and no longer maintained.
 
 =head1 What is VimDebug?
 

--- a/bin/vdd
+++ b/bin/vdd
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # PODNAME: vdd
-# ABSTRACT: The Vim Debugger Daemon
+# ABSTRACT: The Vim Debugger Daemon (DEPRECATED)
 # VERSION
 
 use strict;

--- a/bin/vimdebug-install
+++ b/bin/vimdebug-install
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # PODNAME: vimdebug-install
-# ABSTRACT: Install VimDebug's Vim plugin and doc files.
+# ABSTRACT: Install VimDebug's Vim plugin and doc files. (DEPRECATED)
 # VERSION
 
 =head1 SYNOPSIS
@@ -8,6 +8,8 @@
     vimdebug-install -d $vim_runtimepath_dir
 
 =head1 DESCRIPTION
+
+Please note that this program is deprecated and no longer maintained.
 
 This program installs VimDebug's Vim plugin and doc files in a Vim
 runtimepath directory specified at invocation time.

--- a/dist.ini
+++ b/dist.ini
@@ -21,3 +21,4 @@ weaver_config = @FLORA
     ; Used in script/vim.
 Dir::Self = 0
 
+[Deprecated]

--- a/lib/Vim/Debug.pm
+++ b/lib/Vim/Debug.pm
@@ -1,4 +1,4 @@
-# ABSTRACT: Perl wrapper around a command line debugger
+# ABSTRACT: Perl wrapper around a command line debugger (DEPRECATED)
 
 =head1 SYNOPSIS
 
@@ -22,6 +22,8 @@
     $debugger->quit;
 
 =head1 DESCRIPTION
+
+Please note that this module is deprecated and no longer maintained.
 
 If you are new to Vim::Debug please read the user manual,
 L<Vim::Debug::Manual>, first.

--- a/lib/Vim/Debug/Daemon.pm
+++ b/lib/Vim/Debug/Daemon.pm
@@ -1,4 +1,4 @@
-# ABSTRACT: Handle communication between a debugger and clients
+# ABSTRACT: Handle communication between a debugger and clients (DEPRECATED)
 
 =head1 SYNOPSIS
 
@@ -6,6 +6,8 @@
    Vim::Debug::Daemon->run;
 
 =head1 DESCRIPTION
+
+Please note that this module is deprecated and no longer maintained.
 
 If you are new to Vim::Debug please read the user manual,
 L<Vim::Debug::Manual>, first.

--- a/lib/Vim/Debug/Manual.pm
+++ b/lib/Vim/Debug/Manual.pm
@@ -1,4 +1,4 @@
-# ABSTRACT: Integrate the Perl debugger with Vim
+# ABSTRACT: Integrate the Perl debugger with Vim (DEPRECATED)
 
 =head1 What is VimDebug?
 

--- a/lib/Vim/Debug/Perl.pm
+++ b/lib/Vim/Debug/Perl.pm
@@ -1,6 +1,8 @@
-# ABSTRACT: Perl debugger interface.
+# ABSTRACT: Perl debugger interface. (DEPRECATED)
 
 =head1 DESCRIPTION
+
+Please note that this module is deprecated and no longer maintained.
 
 If you are new to Vim::Debug please read the user manual,
 L<Vim::Debug::Manual>, first.

--- a/lib/Vim/Debug/Protocol.pm
+++ b/lib/Vim/Debug/Protocol.pm
@@ -1,4 +1,4 @@
-# ABSTRACT: Everything needed for the VimDebug network protocol
+# ABSTRACT: Everything needed for the VimDebug network protocol (DEPRECATED)
 
 =head1 SYNOPSIS
 
@@ -15,6 +15,8 @@
     my $response = Vim::Debug::Protocol->respond( $dbgr->status );
 
 =head1 DESCRIPTION
+
+Please note that this module is deprecated and no longer maintained.
 
 If you are new to Vim::Debug please read the user manual,
 L<Vim::Debug::Manual>, first.

--- a/script/vdvim
+++ b/script/vdvim
@@ -2,13 +2,15 @@
 
 =head1 NAME
 
-    vdvim - Launch a minimal vim/gvim with VimDebug development files.
+    vdvim - Launch a minimal vim/gvim with VimDebug development files. (DEPRECATED)
 
 =head1 SYNOPSIS
 
     vdvim [-g] [-m] [$some_file_to_edit]
 
 =head1 DESCRIPTION
+
+Please note that this program is deprecated and no longer maintained.
 
 This program is useful for VimDebug developers to try out things. It
 launches Vim with the VimDebug development code with no interference

--- a/t/lib/Vim/Debug/Client.pm
+++ b/t/lib/Vim/Debug/Client.pm
@@ -1,4 +1,4 @@
-# ABSTRACT: A Vim::Debug client, for testing.
+# ABSTRACT: A Vim::Debug client, for testing. (DEPRECATED)
 
 =head1 SYNOPSIS
 
@@ -6,6 +6,8 @@
     Vim::Debug::Client->connect();
 
 =head1 DESCRIPTION
+
+Please note that this module is deprecated and no longer maintained.
 
 This module implements a Vim::Debug client. The client communicates
 with the Vim::Debug::Daemon.  It's probably only useful for testing.


### PR DESCRIPTION
It was noted that this module is deprecated at
https://github.com/kablamo/VimDebug/issues/37#issuecomment-261698291

This patch adds a note that flags this module as deprecated,
according to http://neilb.org/2015/01/17/deprecated-metadata.html

Please note that in order to make `dzil build` work on my environment, I had to do some more changes that is not included in this pull request: https://github.com/kyzn/VimDebug/commit/3d3607bfa12f15924cc8e99cbec644f9f14c0bce